### PR TITLE
Fixed configure error for testing liballium due to library order

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ PKG_CHECK_MODULES([liballium], [liballium-1.0 >= 0.0.1])
 oldCPPFLAGS=$CPPFLAGS
 oldLDFLAGS=$LDFLAGS
 CPPFLAGS="$CPPFLAGS $liballium_CFLAGS $libevent_CFLAGS"
-LDFLAGS="$LDFLAGS $liballium_LIBS $libevent_LIBS"
+LIBS="$liballium_LIBS $libevent_LIBS $LIBS"
 AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <allium/allium.h>],
                                 [(void)allium_ptcfg_init();])],
                [],


### PR DESCRIPTION
using LDFLAGS leads to conftest.c being put after -lallium. This leads to linker not being able to find references. Using LIBS, the resulting configure file will put conftest.c before -lallium, and the configure script works fine. 

adapted from here: https://lists.gnu.org/archive/html/automake/2005-10/msg00081.html

This would solve some false instances of "configure: error: liballium headers or library missing."
